### PR TITLE
Make prep_oi_counter sequence counter specific to type of service

### DIFF
--- a/api/src/main/java/org/bahmni/module/bahmnipsi/api/PatientIdentifierService.java
+++ b/api/src/main/java/org/bahmni/module/bahmnipsi/api/PatientIdentifierService.java
@@ -2,9 +2,9 @@ package org.bahmni.module.bahmnipsi.api;
 
 public interface PatientIdentifierService {
 
-    int getNextSeqValue();
+    int getNextSeqValue(String sequenceType);
 
     int getIdentifierTypeId(String identifierType);
 
-    void incrementSeqValueByOne(int seqValue);
+    void incrementSeqValueByOne(int seqValue, String sequenceType);
 }

--- a/api/src/main/java/org/bahmni/module/bahmnipsi/api/PatientIdentifierServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/bahmnipsi/api/PatientIdentifierServiceImpl.java
@@ -9,8 +9,8 @@ public class PatientIdentifierServiceImpl implements PatientIdentifierService {
     }
 
     @Override
-    public int getNextSeqValue() {
-        return patientIdentifierDAO.getNextSeqValue();
+    public int getNextSeqValue(String sequenceType) {
+        return patientIdentifierDAO.getNextSeqValue(sequenceType);
     }
 
     @Override
@@ -19,7 +19,7 @@ public class PatientIdentifierServiceImpl implements PatientIdentifierService {
     }
 
     @Override
-    public void incrementSeqValueByOne(int seqValue) {
-        patientIdentifierDAO.incrementSeqValueByOne(seqValue);
+    public void incrementSeqValueByOne(int seqValue, String sequenceType) {
+        patientIdentifierDAO.incrementSeqValueByOne(seqValue, sequenceType);
     }
 }

--- a/api/src/main/java/org/bahmni/module/bahmnipsi/identifier/PatientIdentifierSaveCommandImpl.java
+++ b/api/src/main/java/org/bahmni/module/bahmnipsi/identifier/PatientIdentifierSaveCommandImpl.java
@@ -13,11 +13,12 @@ import java.util.LinkedHashMap;
 
 @Component
 public class PatientIdentifierSaveCommandImpl implements EncounterDataPreSaveCommand {
+    private static final int TWO = 2;
     private final String reasonForVisit = "Reason for visit";
     private final String initialArt = "Initial ART service";
     private final String prepInitial = "PrEP Initial";
-    private static final int TWO = 2;
-
+    private final String INIT_ART_SEQ_TYPE = "INIT_ART_SERVICE";
+    private final String PREP_INIT_SEQ_TYPE = "PrEP_INIT";
     private PatientOiPrepIdentifier patientOiPrepIdentifier;
 
     @Autowired
@@ -32,16 +33,16 @@ public class PatientIdentifierSaveCommandImpl implements EncounterDataPreSaveCom
 
         String requiredObs = checkForArtPrepServiceObs(groupMembers);
 
-        if(!requiredObs.isEmpty()) {
+        if (!requiredObs.isEmpty()) {
             if (requiredObs.equalsIgnoreCase(initialArt)) {
                 try {
-                    patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, "A");
+                    patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, "A", INIT_ART_SEQ_TYPE);
                 } catch (Exception e) {
                     throw new RuntimeException(e.getMessage());
                 }
             } else if (requiredObs.equalsIgnoreCase(prepInitial)) {
                 try {
-                    patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, "P");
+                    patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, "P", PREP_INIT_SEQ_TYPE);
                 } catch (Exception e) {
                     throw new RuntimeException(e.getMessage());
                 }
@@ -58,11 +59,11 @@ public class PatientIdentifierSaveCommandImpl implements EncounterDataPreSaveCom
             if (value != null && value.get("name").equals(initialArt)) {
                 artPrepServiceCount++;
                 requiredObs = initialArt;
-            } else if(value != null && value.get("name").equals(prepInitial)) {
+            } else if (value != null && value.get("name").equals(prepInitial)) {
                 artPrepServiceCount++;
                 requiredObs = prepInitial;
             }
-            if(artPrepServiceCount == TWO) {
+            if (artPrepServiceCount == TWO) {
                 throw new RuntimeException("Both Initial Art Service and Prep Initial can not be selected at time. Please unselect one");
             }
         }

--- a/api/src/main/java/org/bahmni/module/bahmnipsi/identifier/PatientOiPrepIdentifier.java
+++ b/api/src/main/java/org/bahmni/module/bahmnipsi/identifier/PatientOiPrepIdentifier.java
@@ -18,11 +18,11 @@ public class PatientOiPrepIdentifier {
     private final int affixIndex = 14;
     private final int codesLength = 2;
 
-    public void updateOiPrepIdentifier(String patientUuid, String affix) throws Exception {
+    public void updateOiPrepIdentifier(String patientUuid, String affix, String sequenceType) throws Exception {
         PatientIdentifier patientIdentifier = getPatientIdentifier(patientUuid);
 
         if(patientIdentifier == null) {
-            updateIdentifierByUsing(patientUuid, affix);
+            updateIdentifierByUsing(patientUuid, affix, sequenceType);
         }  else {
             String oiPrepIdentifier = patientIdentifier.getIdentifier();
             char existedAffix = oiPrepIdentifier.charAt(affixIndex);
@@ -34,14 +34,14 @@ public class PatientOiPrepIdentifier {
         }
     }
 
-    private void updateIdentifierByUsing(String patientUuid, String affix) throws Exception {
+    private void updateIdentifierByUsing(String patientUuid, String affix, String sequenceType) throws Exception {
         List<String> requiredFields = getRequiredFields(patientUuid);
-        int nextSeqValue = getNextSeqValue();
+        int nextSeqValue = getNextSeqValue(sequenceType);
         String seqValueWithFiveChars = String.format("%0"+ oiPrepIdentifierSuffixLength +"d", nextSeqValue);
         PatientIdentifier patientIdentifier = createIdentifier();
         addIdentifier(patientUuid, patientIdentifier);
         setIdentifier(patientIdentifier, requiredFields, affix, seqValueWithFiveChars);
-        incrementNextSeqValueByOne(nextSeqValue);
+        incrementNextSeqValueByOne(nextSeqValue, sequenceType);
     }
 
     private List<String> getRequiredFields(String patientUuid) {
@@ -106,9 +106,9 @@ public class PatientOiPrepIdentifier {
         return StringUtils.substringBetween(region, "[", "]");
     }
 
-    private int getNextSeqValue() throws Exception {
+    private int getNextSeqValue(String sequenceType) throws Exception {
         try {
-            return Context.getService(PatientIdentifierService.class).getNextSeqValue();
+            return Context.getService(PatientIdentifierService.class).getNextSeqValue(sequenceType);
         } catch (Exception e) {
             throw new RuntimeException("Could not able to get next Sequence Value of the Prep/Oi Identifier");
         }
@@ -118,8 +118,8 @@ public class PatientOiPrepIdentifier {
         patientIdentifier.setIdentifier(requiredFields.get(0)+"-"+requiredFields.get(1)+"-"+requiredFields.get(2)+"-"+requiredFields.get(3)+"-"+affix+"-"+nextSeqValue);
     }
 
-    private void incrementNextSeqValueByOne(int currentSeqValue) {
-        Context.getService(PatientIdentifierService.class).incrementSeqValueByOne(currentSeqValue);
+    private void incrementNextSeqValueByOne(int currentSeqValue, String sequenceType) {
+        Context.getService(PatientIdentifierService.class).incrementSeqValueByOne(currentSeqValue, sequenceType);
     }
 
     private PatientIdentifier getPatientIdentifier(String patientUuid) {

--- a/api/src/main/java/org/bahmni/module/bahmnipsi/identifier/PrepOiCounter.java
+++ b/api/src/main/java/org/bahmni/module/bahmnipsi/identifier/PrepOiCounter.java
@@ -3,9 +3,11 @@ package org.bahmni.module.bahmnipsi.identifier;
 public class PrepOiCounter {
     int id;
     int nextSeqValue;
+    String seqType;
 
-    public PrepOiCounter(int id, int nextSeqValue) {
+    public PrepOiCounter(int id, String seqType, int nextSeqValue) {
         this.id = id;
+        this.seqType = seqType;
         this.nextSeqValue = nextSeqValue;
     }
 
@@ -15,6 +17,14 @@ public class PrepOiCounter {
 
     public void setId(int id) {
         this.id = id;
+    }
+
+    public String getSeqType() {
+        return seqType;
+    }
+
+    public void setSeqType(String seqType) {
+        this.seqType = seqType;
     }
 
     public int getNextSeqValue() {

--- a/api/src/main/resources/PrepOiCounter.hbm.xml
+++ b/api/src/main/resources/PrepOiCounter.hbm.xml
@@ -9,5 +9,6 @@
         </id>
 
         <property name="nextSeqValue" type="int" column="next_seq_value" not-null="true" />
+        <property name="seqType" type="string" column="seq_type" not-null="true" />
     </class>
 </hibernate-mapping>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -5,4 +5,31 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
 
+    <changeSet id="psi-zimb-20190627-1015" author="Dubey" context="psi_omod">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="prep_oi_counter"/>
+            </not>
+        </preConditions>
+        <comment>Creating table prep_oi_counter</comment>
+        <createTable tableName="prep_oi_counter">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="next_seq_value" type="int" defaultValue="0"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="psi-zimb-20190627-1046" author="Dubey" context="psi_omod">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists columnName="seq_type" tableName="prep_oi_counter"/>
+            </not>
+        </preConditions>
+        <comment>Add column seq_type to table prep_oi_counter</comment>
+        <addColumn tableName="prep_oi_counter">
+            <column name="seq_type" type="varchar(255)"/>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/api/src/test/java/org/bahmni/module/bahmnipsi/api/PatientIdentifierDAOTest.java
+++ b/api/src/test/java/org/bahmni/module/bahmnipsi/api/PatientIdentifierDAOTest.java
@@ -9,12 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.openmrs.PatientIdentifier;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.mockito.Mockito.*;
 
@@ -34,6 +29,7 @@ public class PatientIdentifierDAOTest {
 
     private PatientIdentifierDAO patientIdentifierDAO;
     private String identifier, regex;
+    private String initArtService = "INIT_ART_SERVICE";;
 
     @Before
     public void setUp() {
@@ -45,19 +41,50 @@ public class PatientIdentifierDAOTest {
 
     @Test
     public void shouldGetNextSeqValue() {
-        String sql = "select next_seq_value from prep_oi_counter";
+        String sql = "select next_seq_value from prep_oi_counter where seq_type = :sequenceType";
         Integer nextVal = new Integer(3);
 
         when(sessionFactory.getCurrentSession()).thenReturn(session);
         when(session.createSQLQuery(sql)).thenReturn(sqlQuery);
+        when(sqlQuery.setParameter("sequenceType", initArtService)).thenReturn(sqlQuery);
         when(sqlQuery.uniqueResult()).thenReturn(nextVal);
 
-        int expectedVal = patientIdentifierDAO.getNextSeqValue();
+        int expectedVal = patientIdentifierDAO.getNextSeqValue(initArtService);
 
         verify(sessionFactory, times(1)).getCurrentSession();
         verify(session, times(1)).createSQLQuery(sql);
+        verify(sqlQuery, times(1)).setParameter("sequenceType", initArtService);
         verify(sqlQuery, times(1)).uniqueResult();
         Assert.assertEquals(3, expectedVal);
+    }
+
+    @Test
+    public void shouldInitializeSequenceIfNotPresent() {
+        String sql = "select next_seq_value from prep_oi_counter where seq_type = :sequenceType";
+        when(sessionFactory.getCurrentSession()).thenReturn(session);
+        when(session.createSQLQuery(sql)).thenReturn(sqlQuery);
+        when(sqlQuery.setParameter("sequenceType", initArtService)).thenReturn(sqlQuery);
+        when(sqlQuery.uniqueResult()).thenReturn(null);
+
+        String insertSql = "insert into prep_oi_counter(seq_type, next_seq_value) values(:sequenceType, :nextSeqValue)";
+        when(session.createSQLQuery(insertSql)).thenReturn(sqlQuery);
+        when(sqlQuery.setParameter("sequenceType", initArtService)).thenReturn(sqlQuery);
+        when(sqlQuery.setParameter("nextSeqValue", new Integer(0))).thenReturn(sqlQuery);
+        when(sqlQuery.executeUpdate()).thenReturn(1);
+
+        int expectedVal = patientIdentifierDAO.getNextSeqValue(initArtService);
+
+        verify(sessionFactory, times(2)).getCurrentSession();
+        verify(session, times(1)).createSQLQuery(sql);
+        verify(session, times(1)).createSQLQuery(insertSql);
+
+
+        verify(sqlQuery, times(2)).setParameter("sequenceType", initArtService);
+        verify(sqlQuery, times(1)).setParameter("nextSeqValue", new Integer(0));
+        verify(sqlQuery, times(1)).executeUpdate();
+
+
+        Assert.assertEquals(0, expectedVal);
     }
 
     @Test
@@ -81,20 +108,22 @@ public class PatientIdentifierDAOTest {
 
     @Test
     public void shouldIncrementValueByOne() {
-        String sql = "update prep_oi_counter set next_seq_value = :nextValue";
+        String sql = "update prep_oi_counter set next_seq_value = :nextValue where seq_type = :sequenceType";
         int currentValue = 4;
         int nextVal = 5;
 
         when(sessionFactory.getCurrentSession()).thenReturn(session);
         when(session.createSQLQuery(sql)).thenReturn(sqlQuery);
         when(sqlQuery.setParameter("nextValue", nextVal)).thenReturn(query);
+        when(query.setParameter("sequenceType", initArtService)).thenReturn(query);
         when(query.executeUpdate()).thenReturn(nextVal);
 
-        patientIdentifierDAO.incrementSeqValueByOne(currentValue);
+        patientIdentifierDAO.incrementSeqValueByOne(currentValue, initArtService);
 
         verify(sessionFactory, times(1)).getCurrentSession();
         verify(session, times(1)).createSQLQuery(sql);
         verify(sqlQuery, times(1)).setParameter("nextValue", nextVal);
+        verify(query, times(1)).setParameter("sequenceType", initArtService);
         verify(query, times(1)).executeUpdate();
     }
 }

--- a/api/src/test/java/org/bahmni/module/bahmnipsi/api/PatientIdentifierServiceImplTest.java
+++ b/api/src/test/java/org/bahmni/module/bahmnipsi/api/PatientIdentifierServiceImplTest.java
@@ -26,11 +26,11 @@ public class PatientIdentifierServiceImplTest {
     public void shouldGetNextValue() {
         int expectedOutput = 2;
 
-        when(patientIdentifierDAO.getNextSeqValue()).thenReturn(2);
+        when(patientIdentifierDAO.getNextSeqValue("INIT_ART_SERVICE")).thenReturn(2);
 
-        int actualOutput = impl.getNextSeqValue();
+        int actualOutput = impl.getNextSeqValue("INIT_ART_SERVICE");
 
-        verify(patientIdentifierDAO, times(1)).getNextSeqValue();
+        verify(patientIdentifierDAO, times(1)).getNextSeqValue("INIT_ART_SERVICE");
         Assert.assertEquals(expectedOutput, actualOutput);
     }
 
@@ -50,10 +50,10 @@ public class PatientIdentifierServiceImplTest {
     @Test
     public void shouldCallDAOIncrementMethod() {
         int seqValue = 2;
-        doNothing().when(patientIdentifierDAO).incrementSeqValueByOne(seqValue);
+        doNothing().when(patientIdentifierDAO).incrementSeqValueByOne(seqValue, "INIT_ART_SERVICE");
 
-        impl.incrementSeqValueByOne(seqValue);
-        verify(patientIdentifierDAO, times(1)).incrementSeqValueByOne(seqValue);
+        impl.incrementSeqValueByOne(seqValue, "INIT_ART_SERVICE");
+        verify(patientIdentifierDAO, times(1)).incrementSeqValueByOne(seqValue, "INIT_ART_SERVICE");
     }
 
 }

--- a/api/src/test/java/org/bahmni/module/bahmnipsi/identifier/PatientIdentifierSaveCommandImplTest.java
+++ b/api/src/test/java/org/bahmni/module/bahmnipsi/identifier/PatientIdentifierSaveCommandImplTest.java
@@ -55,21 +55,21 @@ public class PatientIdentifierSaveCommandImplTest {
     @Test
     public void shouldCallUpdateOiPrepIdentifierWithAffixAWhenServiceIsInitialArt() throws Exception {
         patientIdentifierSaveCommandImpl.setPatientOiPrepIdentifier(patientOiPrepIdentifier);
-        doNothing().when(patientOiPrepIdentifier).updateOiPrepIdentifier(patientUuid, "A");
+        doNothing().when(patientOiPrepIdentifier).updateOiPrepIdentifier(patientUuid, "A", "INIT_ART_SERVICE");
         BahmniEncounterTransaction bahmniEncounterTransaction = PatientTestData.setUpEncounterTransactionDataWith(initialArtService,conceptName, patientUuid);
         patientIdentifierSaveCommandImpl.update(bahmniEncounterTransaction);
 
-        verify(patientOiPrepIdentifier, times(1)).updateOiPrepIdentifier(patientUuid, "A");
+        verify(patientOiPrepIdentifier, times(1)).updateOiPrepIdentifier(patientUuid, "A", "INIT_ART_SERVICE");
     }
 
     @Test
     public void shouldCallUpdateOiPrepIdentifierWithAffixPWhenServiceIsPrepInitial() throws Exception {
         patientIdentifierSaveCommandImpl.setPatientOiPrepIdentifier(patientOiPrepIdentifier);
-        doNothing().when(patientOiPrepIdentifier).updateOiPrepIdentifier(patientUuid, "P");
+        doNothing().when(patientOiPrepIdentifier).updateOiPrepIdentifier(patientUuid, "P", "PrEP_INIT");
         BahmniEncounterTransaction bahmniEncounterTransaction = PatientTestData.setUpEncounterTransactionDataWith(prepInitial, conceptName, patientUuid);
         patientIdentifierSaveCommandImpl.update(bahmniEncounterTransaction);
 
-        verify(patientOiPrepIdentifier, times(1)).updateOiPrepIdentifier(patientUuid, "P");
+        verify(patientOiPrepIdentifier, times(1)).updateOiPrepIdentifier(patientUuid, "P", "PrEP_INIT");
     }
 
     @Test
@@ -77,11 +77,11 @@ public class PatientIdentifierSaveCommandImplTest {
         patientIdentifierSaveCommandImpl.setPatientOiPrepIdentifier(patientOiPrepIdentifier);
         exception.expect(RuntimeException.class);
 
-        doThrow(RuntimeException.class).when(patientOiPrepIdentifier).updateOiPrepIdentifier(patientUuid, "A");
+        doThrow(RuntimeException.class).when(patientOiPrepIdentifier).updateOiPrepIdentifier(patientUuid, "A", "INIT_ART_SERVICE");
         BahmniEncounterTransaction bahmniEncounterTransaction = PatientTestData.setUpEncounterTransactionDataWith(initialArtService, conceptName, patientUuid);
         patientIdentifierSaveCommandImpl.update(bahmniEncounterTransaction);
 
-        verify(patientOiPrepIdentifier, times(1)).updateOiPrepIdentifier(patientUuid, "A");
+        verify(patientOiPrepIdentifier, times(1)).updateOiPrepIdentifier(patientUuid, "A", "INIT_ART_SERVICE");
     }
 
     @Test
@@ -89,11 +89,11 @@ public class PatientIdentifierSaveCommandImplTest {
         patientIdentifierSaveCommandImpl.setPatientOiPrepIdentifier(patientOiPrepIdentifier);
         exception.expect(RuntimeException.class);
 
-        doThrow(RuntimeException.class).when(patientOiPrepIdentifier).updateOiPrepIdentifier(patientUuid, "P");
+        doThrow(RuntimeException.class).when(patientOiPrepIdentifier).updateOiPrepIdentifier(patientUuid, "P", "PrEP_INIT");
         BahmniEncounterTransaction bahmniEncounterTransaction = PatientTestData.setUpEncounterTransactionDataWith(prepInitial, conceptName, patientUuid);
         patientIdentifierSaveCommandImpl.update(bahmniEncounterTransaction);
 
-        verify(patientOiPrepIdentifier, times(1)).updateOiPrepIdentifier(patientUuid, "P");
+        verify(patientOiPrepIdentifier, times(1)).updateOiPrepIdentifier(patientUuid, "P", "PrEP_INIT");
     }
 
     @Test
@@ -137,8 +137,8 @@ public class PatientIdentifierSaveCommandImplTest {
 
         patientIdentifierSaveCommandImpl.update(bahmniEncounterTransaction);
 
-        verify(patientOiPrepIdentifier, times(0)).updateOiPrepIdentifier(patientUuid, "A");
-        verify(patientOiPrepIdentifier, times(0)).updateOiPrepIdentifier(patientUuid, "P");
+        verify(patientOiPrepIdentifier, times(0)).updateOiPrepIdentifier(patientUuid, "A", "INIT_ART_SERVICE");
+        verify(patientOiPrepIdentifier, times(0)).updateOiPrepIdentifier(patientUuid, "P", "INIT_ART_SERVICE");
     }
 
     @Test
@@ -147,8 +147,8 @@ public class PatientIdentifierSaveCommandImplTest {
 
         patientIdentifierSaveCommandImpl.update(bahmniEncounterTransaction);
 
-        verify(patientOiPrepIdentifier, times(0)).updateOiPrepIdentifier(patientUuid, "A");
-        verify(patientOiPrepIdentifier, times(0)).updateOiPrepIdentifier(patientUuid, "P");
+        verify(patientOiPrepIdentifier, times(0)).updateOiPrepIdentifier(patientUuid, "A", "INIT_ART_SERVICE");
+        verify(patientOiPrepIdentifier, times(0)).updateOiPrepIdentifier(patientUuid, "P", "INIT_ART_SERVICE");
 
     }
 }

--- a/api/src/test/java/org/bahmni/module/bahmnipsi/identifier/PatientOiPrepIdentifierTest.java
+++ b/api/src/test/java/org/bahmni/module/bahmnipsi/identifier/PatientOiPrepIdentifierTest.java
@@ -73,7 +73,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Province should not be empty on the Registration first page to generate Prep/Oi Identifier.");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -86,7 +86,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("District should not be empty on the Registration first page to generate Prep/Oi Identifier.");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -101,7 +101,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Facility should not be empty on the Registration first page to generate Prep/Oi Identifier.");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -116,7 +116,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Province, District should not be empty on the Registration first page to generate Prep/Oi Identifier.");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -131,7 +131,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Province, Facility should not be empty on the Registration first page to generate Prep/Oi Identifier.");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -146,7 +146,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("District, Facility should not be empty on the Registration first page to generate Prep/Oi Identifier.");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -162,7 +162,7 @@ public class PatientOiPrepIdentifierTest {
             exception.expect(RuntimeException.class);
             exception.expectMessage("Province, District, Facility should not be empty on the Registration first page to generate Prep/Oi Identifier.");
 
-            patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+            patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
         }
 
     @Test
@@ -177,7 +177,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Please enter the Province code in the square brackets example 'MIDLANDS[07]' and code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -192,7 +192,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Please enter the District code in the square brackets example 'MIDLANDS[07]' and code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -207,7 +207,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Please enter the Facility code in the square brackets example 'MIDLANDS[07]' and code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -223,7 +223,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Please enter the Province, District code in the square brackets example 'MIDLANDS[07]' and code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix,"INIT_ART_SERVICE" );
     }
 
     @Test
@@ -239,7 +239,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Please enter the Province, Facility code in the square brackets example 'MIDLANDS[07]' and code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -255,7 +255,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Please enter the District, Facility code in the square brackets example 'MIDLANDS[07]' and code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -272,7 +272,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Please enter the Province, District, Facility code in the square brackets example 'MIDLANDS[07]' and code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -288,7 +288,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Province code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -304,7 +304,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("District code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -320,7 +320,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Facility code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -338,7 +338,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Province, District code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -356,7 +356,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Province, Facility code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -373,7 +373,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("District, Facility code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -392,7 +392,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Province, District, Facility code length must be 2");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -404,12 +404,12 @@ public class PatientOiPrepIdentifierTest {
         setUpMocks(patient);
         when(personAddress.getStateProvince()).thenReturn(province);
         when(StringUtils.substringBetween(province, "[", "]")).thenReturn("0D");
-        doThrow(RuntimeException.class).when(patientIdentifierService).getNextSeqValue();
+        doThrow(RuntimeException.class).when(patientIdentifierService).getNextSeqValue("INIT_ART_SERVICE");
 
         exception.expect(RuntimeException.class);
         exception.expectMessage("Could not able to get next Sequence Value of the Prep/Oi Identifier");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -424,12 +424,12 @@ public class PatientOiPrepIdentifierTest {
         setUpMocks(patient);
         when(personAddress.getStateProvince()).thenReturn(province);
         when(StringUtils.substringBetween(province, "[", "]")).thenReturn("0D");
-        when(patientIdentifierService.getNextSeqValue()).thenReturn(nextSeqValue);
+        when(patientIdentifierService.getNextSeqValue("INIT_ART_SERVICE")).thenReturn(nextSeqValue);
         when(String.format("%05d", nextSeqValue)).thenReturn(suffix);
         doNothing().when(patientIdentifier).setIdentifier(identifier);
-        doNothing().when(patientIdentifierService).incrementSeqValueByOne(nextSeqValue + 1);
+        doNothing().when(patientIdentifierService).incrementSeqValueByOne(nextSeqValue + 1, "INIT_ART_SERVICE");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix);
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, affix, "INIT_ART_SERVICE");
 
         verifyStatic(VerificationModeFactory.times(2));
         Context.getPatientService();
@@ -448,11 +448,11 @@ public class PatientOiPrepIdentifierTest {
         verify(personAddress, times(1)).getStateProvince();
         verify(personAddress, times(1)).getCityVillage();
         verify(personAddress, times(1)).getAddress2();
-        verify(patientIdentifierService, times(1)).getNextSeqValue();
+        verify(patientIdentifierService, times(1)).getNextSeqValue("INIT_ART_SERVICE");
         verify(patientIdentifierService, times(1)).getIdentifierTypeId(identifierType);
         verify(patientIdentifier, times(1)).setIdentifierType(patientIdentifierType);
         verify(patientIdentifier, times(1)).setIdentifier(identifier);
-        verify(patientIdentifierService, times(1)).incrementSeqValueByOne(nextSeqValue);
+        verify(patientIdentifierService, times(1)).incrementSeqValueByOne(nextSeqValue, "INIT_ART_SERVICE");
     }
 
     @Test
@@ -463,7 +463,7 @@ public class PatientOiPrepIdentifierTest {
         exception.expect(RuntimeException.class);
         exception.expectMessage("Can not change visit type from Initial Art Service to Prep Initial");
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, "P");
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, "P", "INIT_ART_SERVICE");
 
         verifyStatic(VerificationModeFactory.times(1));
         Context.getPatientService();
@@ -477,7 +477,7 @@ public class PatientOiPrepIdentifierTest {
         patient = PatientTestData.setOiPrepIdentifierToPatient(identifier);
         setUpMocks(patient);
 
-        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, "A");
+        patientOiPrepIdentifier.updateOiPrepIdentifier(patientUuid, "A", "INIT_ART_SERVICE");
 
         Assert.assertEquals("00-OA-63-2017-A-01368", patient.getPatientIdentifier(identifierType).getIdentifier());
     }


### PR DESCRIPTION
This PR makes the `prep_oi_counter` sequence counter specific of the services chosen. To achieve the same, the `prep_oi_counter` has got a column `seq_type`. This `seq_type` will have the counter for a specific service(PrEP/ART). 
The following things are done as part of this PR:

- [x] Introduce migration for the creation of `prep_oi_counter`. As of now, it will skip since the table is already present.
- [x] Introduce migration for adding column `seq_type`. 
- [x] Change `PatientIdentifierDAO` to `get` and `update` the next sequence value for the service selected.
- [x] Change `PatientIdentifierDAO` initialize sequence for service if there is first registration for that.

To Migrate existing sequence we can run below queries which will figure out the number of distinct patients registered for specific service and then run an insert query. Tested on the local environment. 

```
# Initial ART service
select count(distinct(person_id)) from obs where value_coded = (select concept_id from concept_name where name = 'Initial ART service' and concept_name_type = 'FULLY_SPECIFIED');
insert_into prep_oi_counter(seq_type, next_seq_value) values('INIT_ART_SERVICE', <count from above> + 1);

# PrEP Initial
select count(distinct(person_id)) from obs where value_coded = (select concept_id from concept_name where name = 'PrEP Initial' and concept_name_type = 'FULLY_SPECIFIED');
insert_into prep_oi_counter(seq_type, next_seq_value) values('PrEP_INIT', <count from above> + 1);
```